### PR TITLE
Fix theme not updating immediately when changed in settings

### DIFF
--- a/list.js
+++ b/list.js
@@ -637,6 +637,7 @@ class InstantList {
     applySettings() {
         this.settingsManager.updateFromDOM();
         this.settingsManager.saveToCookies();
+        this.settingsManager.applyTheme();
 
         this.config.itemsPerPage = this.settingsManager.generalSettings.itemsPerPage;
         this.table.updateItemsPerPage(this.config.itemsPerPage);


### PR DESCRIPTION
Added applyTheme() call in applySettings() method so the theme is applied right after saving, without requiring a page reload.

https://claude.ai/code/session_01Fc4E3ZobiZPFuWyAX1MNMJ